### PR TITLE
crypto: Add missing member

### DIFF
--- a/include/crypto/hash.h
+++ b/include/crypto/hash.h
@@ -94,6 +94,7 @@ struct crypto_ahash {
 		      unsigned int keylen);
 
 	unsigned int reqsize;
+	bool has_setkey
 	struct crypto_tfm base;
 };
 


### PR DESCRIPTION
Add the missing member as referenced to by this log 
https://hastebin.com/onubeqahol.go

Where did this member dissappear to?